### PR TITLE
検索結果一覧画面からエンジニア詳細画面を表示

### DIFF
--- a/src/app/mypage/_lib/userFetch.tsx
+++ b/src/app/mypage/_lib/userFetch.tsx
@@ -67,6 +67,13 @@ export const userFetch = (isTrue: boolean, argId: number) => {
   });
   useEffect(() => {
     const fetchId = async () => {
+      // argIdかcookies.userIdがundefinedの場合、APIのリクエストを実行しない
+      if (
+        (!isTrue && typeof cookies.userId === 'undefined') ||
+        (isTrue && typeof argId === 'undefined')
+      ) {
+        return;
+      }
       try {
         const getUserData = await axios.get(
           `${process.env.NEXT_PUBLIC_API_URL}/users?userId=${

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -5,11 +5,25 @@ import '../globals.css';
 import Skillview from '@/components/mypage/Skillview';
 import Specview from '@/components/mypage/Specview';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { userFetch } from './_lib/userFetch';
 
+
 const Page = () => {
-  const userData = userFetch(false, 0);
+  // URLのクエリパラメータから取得したuserIdを保持するステート
+  const [userId, setUserId] = useState<string | null>(null);
+  // コンポーネントのマウント時、またはURLが変更された時にuserIdを更新する
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const uid = searchParams.get('userId');
+    setUserId(uid);
+  }, []);
+  // userIdが存在する場合は数値に変換、存在しない場合は0をデフォルトとして設定
+  let argId = userId ? Number(userId) : 0;
+  // userIdの有無に応じてAPIからユーザデータを取得
+  let userData = userId
+    ? userFetch(true, argId)
+    : userFetch(false, 0);
 
   // タブの切り替え
   const selected =
@@ -69,16 +83,30 @@ const Page = () => {
             {pageState ? 'スキルシート' : 'スペックシート'}
           </h2>
           <div className="text-center">
-            <Link href={pageState ? '/skilledit' : '/specseat'}>
-              <button
-                type="button"
-                className="shadow-md h-12 ml-2 relative bottom-2 cursor-pointer bg-gradient-to-b from-orange-400 to-yellow-400 rounded-xl border-2 border-white border-solid transition-all"
-              >
-                <span className="text-white font-bold m-5 text-lg">
-                  編集
-                </span>
-              </button>
-            </Link>
+            {userId ? (
+              <a>
+                <button
+                  type="button"
+                  onClick={() => window.history.back()}
+                  className="shadow-md h-12 ml-2 relative bottom-2 cursor-pointer bg-gradient-to-b from-orange-400 to-yellow-400 rounded-xl border-2 border-white border-solid transition-all"
+                >
+                  <span className="text-white font-bold m-5 text-lg">
+                    一覧に戻る
+                  </span>
+                </button>
+              </a>
+            ) : (
+              <Link href={pageState ? '/skilledit' : '/specseat'}>
+                <button
+                  type="button"
+                  className="shadow-md h-12 ml-2 relative bottom-2 cursor-pointer bg-gradient-to-b from-orange-400 to-yellow-400 rounded-xl border-2 border-white border-solid transition-all"
+                >
+                  <span className="text-white font-bold m-5 text-lg">
+                    編集
+                  </span>
+                </button>
+              </Link>
+            )}
           </div>
         </div>
 

--- a/src/pages/searchResult/searchSales.tsx
+++ b/src/pages/searchResult/searchSales.tsx
@@ -31,6 +31,7 @@ const SearchSales = ({
 }: {
   query: Query;
 }) => {
+  const router = useRouter();
   const [users, setUsers] = useState(JSON.parse(query.foundUser));
   const [businessSituation, setBusinessSituation] = useState('');
 
@@ -47,6 +48,11 @@ const SearchSales = ({
   //   window.location.reload();
   //   return <div>Loading...</div>;
   // }
+
+  const redirectToMyPage = (userId:number) => {
+    // /mypage/page へリダイレクトし、クエリパラメーターとして userId を付加
+    router.push(`/mypage?userId=${userId}`);
+  }
 
   const handleChange = async (user: User) => {
     try {
@@ -136,6 +142,7 @@ const SearchSales = ({
                     <a
                       href="#"
                       className="relative flex justify-center space-x-32 mr-10 mb-2"
+                      onClick={() =>redirectToMyPage(user.userId)}
                     >
                       <div
                         className="absolute"


### PR DESCRIPTION
## やったこと

このプルリクで何をしたのか？
・検索結果一覧画面からエンジニア詳細画面へのリダイレクト。
・スペックシート表示画面で検証ツールをみてエラーが発生するのは今回の変更とは関係ないものと思われる。（デプロイ前に修正予定）
・クエリを受け取る際にrouterやSSRを使用しなかったのはapp配下のファイルだとこれらは使用できないとのことだったため。

## できるようになること（ユーザ目線）

何ができるようになるのか？

